### PR TITLE
Rewrite tests to use mocks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,47 +9,29 @@ script:
 matrix:
   include:
   - python: 2.7
-    env: TOXENV=py27-django17
-  - python: 2.7
-    env: TOXENV=py27-django18
-  - python: 2.7
-    env: TOXENV=py27-django19
-  - python: 2.7
-    env: TOXENV=py27-django110
-  - python: 2.7
     env: TOXENV=py27-django111
   - python: 3.4
-    env: TOXENV=py34-django17
-  - python: 3.4
-    env: TOXENV=py34-django18
-  - python: 3.4
-    env: TOXENV=py34-django19
-  - python: 3.4
-    env: TOXENV=py34-django110
-  - python: 3.4
     env: TOXENV=py34-django111
-  - python: 3.4
-    env: TOXENV=py34-django20
-  - python: 3.5
-    env: TOXENV=py35-django18
-  - python: 3.5
-    env: TOXENV=py35-django19
-  - python: 3.5
-    env: TOXENV=py35-django110
   - python: 3.5
     env: TOXENV=py35-django111
   - python: 3.5
-    env: TOXENV=py35-django20
-  - python: 3.6
-    env: TOXENV=py36-django18
-  - python: 3.6
-    env: TOXENV=py36-django19
-  - python: 3.6
-    env: TOXENV=py36-django110
+    env: TOXENV=py35-django22
   - python: 3.6
     env: TOXENV=py36-django111
   - python: 3.6
-    env: TOXENV=py36-django20
+    env: TOXENV=py36-django22
+  - python: 3.6
+    env: TOXENV=py36-django30
+  - python: 3.7
+    env: TOXENV=py37-django111
+  - python: 3.7
+    env: TOXENV=py37-django22
+  - python: 3.7
+    env: TOXENV=py37-django30
+  - python: 3.8
+    env: TOXENV=py38-django22
+  - python: 3.8
+    env: TOXENV=py38-django30
 env:
   global:
   - secure: BvefwB7dAyxeVeIwaDoklOwE04DkuP4xqj18awneFYJdln2qWUB/AcchVGrp6Toi1XnL+4e/CkSRbj/XLr3FBceARknfgzT3zp7BQyJLREAXFXV75dcCtcN9Jxh4IMpNlLTcZcB8OvU+edrRulmsOR0hXIie8rLg3pt+2LfGxhVzaUBq6F9vv+Db7tdZ+DNnciA+geJQZ+ThtxxUzVcNqCgTvQSrPYMGx07ScEG6MuEakHopEVuTE3n7hiOZW/17sS4uBfj+JwL3RX1gg/lnobbicYxBJ+WzuIP2cpVGLDJDwnclqlAezPMEG0AymeOrM9/5fYRkyawOyeaJZFmcd4cqnKurG/lDmidABzB3LXYWnAYVMOsQ5R9JqRRa+AVHt8u1wJZu4VXMoI7AtLHaMCVBO0iAGkH7dD41oy/aMzN63bIp+ANo7seIouxRfCX62H5+1unUbYYExsKvUhwb7uSLLq67QcbkudklIpb/xsNkueqFgJ9APBH3/K7MYjRjPrCA8pjOgnWXyzJRty+fZctrJZTbWg9ubky7t/48enDmFzDOgMjnEtkKAXYO7lHDEsA2HceLtYx08VI9Hfry579AhdqZSRaXZejSN8ZUIOHJLXT+2Md35IuySTpqkQiEjDYWwhLooEFvrirVB+3YCw6Sw6kAoT7P5FS2hOOZtKw=

--- a/algoliasearch_django/models.py
+++ b/algoliasearch_django/models.py
@@ -83,10 +83,7 @@ class AlgoliaIndex(object):
         if self.settings is None:  # Only set settings if the actual index class does not define some
             self.settings = {}
 
-        try:
-            all_model_fields = [f.name for f in model._meta.get_fields() if not f.is_relation]
-        except AttributeError:  # get_fields requires Django >= 1.8
-            all_model_fields = [f.name for f in model._meta.local_fields]
+        all_model_fields = [f.name for f in model._meta.get_fields() if not f.is_relation]
 
         if isinstance(self.fields, str):
             self.fields = (self.fields,)

--- a/algoliasearch_django/models.py
+++ b/algoliasearch_django/models.py
@@ -457,7 +457,7 @@ class AlgoliaIndex(object):
                     self.settings['slaves'] = []
                     logger.debug("REMOVE SLAVES FROM SETTINGS")
 
-                self.__tmp_index.wait_task(self.__tmp_index.set_settings(self.settings)['taskID'])
+                self.__tmp_index.wait_task(self.__tmp_index.set_settings(self.settings.copy())['taskID'])
                 logger.debug('APPLY SETTINGS ON %s_tmp', self.index_name)
             rules = []
             synonyms = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ tox
 twine
 factory_boy
 mock
+six

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -29,7 +29,7 @@ INSTALLED_APPS = (
     'tests'
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -39,6 +39,19 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
 )
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    },
+]
 
 ROOT_URLCONF = 'tests.urls'
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,7 +1,7 @@
 from mock import patch, call, Mock
 
 from django.test import TestCase
-from django.utils.six import StringIO
+from six import StringIO
 from django.core.management import call_command
 
 from .models import Website

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,133 +1,66 @@
+from mock import patch, call, Mock
+
 from django.test import TestCase
 from django.utils.six import StringIO
 from django.core.management import call_command
-
-from algoliasearch_django import algolia_engine
-from algoliasearch_django import get_adapter
-from algoliasearch_django import clear_index
 
 from .models import Website
 from .models import User
 
 
 class CommandsTestCase(TestCase):
-    @classmethod
-    def tearDownClass(cls):
-        algolia_engine.client.delete_index(get_adapter(User).index_name)
-        algolia_engine.client.delete_index(get_adapter(Website).index_name)
-
-    def setUp(self):
-        # Create some records
-        User.objects.create(name='James Bond', username="jb")
-        User.objects.create(name='Captain America', username="captain")
-        User.objects.create(name='John Snow', username="john_snow",
-                            _lat=120.2, _lng=42.1)
-        User.objects.create(name='Steve Jobs', username="genius",
-                            followers_count=331213)
-
-        self.out = StringIO()
-
-    def tearDown(self):
-        clear_index(Website)
-        clear_index(User)
 
     def test_reindex(self):
-        call_command('algolia_reindex', stdout=self.out)
-        result = self.out.getvalue()
-
-        regex = r'Website --> 0'
-        try:
-            self.assertRegex(result, regex)
-        except AttributeError:
-            self.assertRegexpMatches(result, regex)
-
-        regex = r'User --> 4'
-        try:
-            self.assertRegex(result, regex)
-        except AttributeError:
-            self.assertRegexpMatches(result, regex)
+        with patch("algoliasearch_django.management.commands.algolia_reindex.reindex_all") as mock_reindex:
+            call_command('algolia_reindex', stdout=StringIO())
+        mock_reindex.assert_has_calls([
+            call(Website, batch_size=1000),
+            call(User, batch_size=1000)
+        ], any_order=True)
 
     def test_reindex_with_args(self):
-        call_command('algolia_reindex', stdout=self.out, model=['Website'])
-        result = self.out.getvalue()
-
-        regex = r'Website --> \d+'
-        try:
-            self.assertRegex(result, regex)
-        except AttributeError:
-            self.assertRegexpMatches(result, regex)
-
-        regex = r'User --> \d+'
-        try:
-            self.assertNotRegex(result, regex)
-        except AttributeError:
-            self.assertNotRegexpMatches(result, regex)
+        with patch("algoliasearch_django.management.commands.algolia_reindex.reindex_all") as mock_reindex:
+            call_command('algolia_reindex', stdout=StringIO(), model=['Website'])
+        mock_reindex.assert_called_once_with(Website, batch_size=1000)
 
     def test_clearindex(self):
-        call_command('algolia_clearindex', stdout=self.out)
-        result = self.out.getvalue()
-
-        regex = r'Website'
-        try:
-            self.assertRegex(result, regex)
-        except AttributeError:
-            self.assertRegexpMatches(result, regex)
-
-        regex = r'User'
-        try:
-            self.assertRegex(result, regex)
-        except AttributeError:
-            self.assertRegexpMatches(result, regex)
+        with patch("algoliasearch_django.management.commands.algolia_clearindex.clear_index") as mock_clear:
+            call_command('algolia_clearindex', stdout=StringIO())
+        mock_clear.assert_has_calls([
+            call(Website),
+            call(User)
+        ], any_order=True)
 
     def test_clearindex_with_args(self):
-        call_command(
-            'algolia_clearindex',
-            stdout=self.out,
-            model=['Website']
-        )
-        result = self.out.getvalue()
-
-        regex = r'Website'
-        try:
-            self.assertRegex(result, regex)
-        except AttributeError:
-            self.assertRegexpMatches(result, regex)
-
-        regex = r'User'
-        try:
-            self.assertNotRegex(result, regex)
-        except AttributeError:
-            self.assertNotRegexpMatches(result, regex)
+        with patch("algoliasearch_django.management.commands.algolia_clearindex.clear_index") as mock_clear:
+            call_command(
+                'algolia_clearindex',
+                stdout=StringIO(),
+                model=['Website']
+            )
+        mock_clear.assert_called_once_with(Website)
 
     def test_applysettings(self):
-        call_command('algolia_applysettings', stdout=self.out)
-        result = self.out.getvalue()
+        with patch("algoliasearch_django.management.commands.algolia_applysettings.get_adapter") as mock_get_adapter:
+            mock_adapter = Mock()
+            mock_get_adapter.return_value = mock_adapter
+            call_command('algolia_applysettings', stdout=StringIO())
 
-        regex = r'Website'
-        try:
-            self.assertRegex(result, regex)
-        except AttributeError:
-            self.assertRegexpMatches(result, regex)
+        mock_get_adapter.assert_has_calls([
+            call(Website),
+            call(User)
+        ], any_order=True)
 
-        regex = r'User'
-        try:
-            self.assertRegex(result, regex)
-        except AttributeError:
-            self.assertRegexpMatches(result, regex)
+        mock_adapter.set_settings.assert_has_calls([
+            call(),
+            call()
+        ])
 
     def test_applysettings_with_args(self):
-        call_command('algolia_applysettings', stdout=self.out,
-                     model=['Website'])
-        result = self.out.getvalue()
+        with patch("algoliasearch_django.management.commands.algolia_applysettings.get_adapter") as mock_get_adapter:
+            mock_adapter = Mock()
+            mock_get_adapter.return_value = mock_adapter
+            call_command('algolia_applysettings', stdout=StringIO(), model=['Website'])
 
-        regex = r'Website'
-        try:
-            self.assertRegex(result, regex)
-        except AttributeError:
-            self.assertRegexpMatches(result, regex)
-
-        regex = r'User'
-        try:
-            self.assertNotRegex(result, regex)
-        except AttributeError:
-            self.assertNotRegexpMatches(result, regex)
+        mock_get_adapter.assert_called_once_with(Website)
+        mock_adapter.set_settings.assert_called_once()

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,8 @@
 [tox]
 envlist =
-    {py27,py34}-django17
-    {py27,py34,py35,py36}-django18
-    {py27,py34,py35,py36}-django19
-    {py27,py34,py35,py36}-django110
-    {py27,py34,py35,py36}-django111
-    {py34,py35,py36}-django20
-    coverage
+    {py27,py34,py35,py36,py37}-django111
+    {py35,py36,py37,py38}-django22
+    {py36,py37,py38}-django30
 skip_missing_interpreters = True
 
 [testenv]
@@ -14,12 +10,9 @@ deps =
     six
     mock
     factory_boy
-    django17: Django>=1.7,<1.8
-    django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
-    django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2.0
-    django20: Django>=2.0,<2.1
+    django22: Django>=2.2,<3.0
+    django30: Django>=3.0,<3.1
 passenv =
     ALGOLIA*
     TRAVIS*


### PR DESCRIPTION
`algoliasearch-django` interacts with Algolia via its Python client library. We should use mocks to test that we make the correct function calls, and trust the client library to do its job.

- [x] Commands
- [x] Decorators
- [x] Engine
- [x] Index
- [x] Signal