### PR TITLE
Run tests using GitHub Actions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,23 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox tox-gh-actions
+    - name: Test with tox
+      run: tox

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -79,8 +79,8 @@ def safe_index_name(name):
 
 # AlgoliaSearch settings
 ALGOLIA = {
-    'APPLICATION_ID': os.getenv('ALGOLIA_APPLICATION_ID'),
-    'API_KEY': os.getenv('ALGOLIA_API_KEY'),
+    'APPLICATION_ID': 'XXX',
+    'API_KEY': 'YYY',
     'INDEX_PREFIX': 'test',
     'INDEX_SUFFIX': safe_index_name('django'),
     'RAISE_EXCEPTIONS': True

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,14 @@ envlist =
     {py36,py37,py38}-django30
 skip_missing_interpreters = True
 
+[gh-actions]
+python =
+    2.7: py27
+    3.5: py35
+    3.6: py36
+    3.7: py37
+    3.8: py38
+
 [testenv]
 deps =
     six


### PR DESCRIPTION
Run tox on Github Actions. 

Unfortunately it doesn't support Python 3.4, but that's only supported by Django 1.11 which is EOL'd, and we plan to remove shortly.