### PR TITLE
Refactor indexes

### DIFF
--- a/algoliasearch_django/models/__init__.py
+++ b/algoliasearch_django/models/__init__.py
@@ -1,0 +1,1 @@
+from .index import AlgoliaIndex, AlgoliaIndexError

--- a/algoliasearch_django/models/__init__.py
+++ b/algoliasearch_django/models/__init__.py
@@ -1,1 +1,2 @@
-from .index import AlgoliaIndex, AlgoliaIndexError
+from .base import AlgoliaIndexError
+from .index import AlgoliaIndex

--- a/algoliasearch_django/models/base.py
+++ b/algoliasearch_django/models/base.py
@@ -1,0 +1,384 @@
+import logging
+
+from algoliasearch.helpers import AlgoliaException
+
+from ..settings import DEBUG
+
+
+logger = logging.getLogger(__name__)
+
+
+class AlgoliaIndexError(Exception):
+    """Something went wrong with an Algolia Index."""
+
+
+class BaseAlgoliaIndex(object):
+
+    # Use to specify the fields that should be included in the index.
+    fields = ()
+
+    # Use to specify the geo-fields that should be used for location search.
+    # The attribute should be a callable that returns a tuple.
+    geo_field = None
+
+    # Use to specify the field that should be used for filtering by tag.
+    tags = None
+
+    # Use to specify the index to target on Algolia.
+    index_name = None
+
+    # Use to specify the settings of the index.
+    settings = None
+
+    # Used to specify if the instance should be indexed.
+    # The attribute should be either:
+    # - a callable that returns a boolean.
+    # - a BooleanField
+    # - a boolean property or attribute
+    should_index = None
+
+    def __init__(self, client, settings):
+        self.__client = client
+        self._named_fields = {}
+        self._translate_fields = {}
+
+        if self.settings is None:  # Only set settings if the actual index class does not define some
+            self.settings = {}
+
+        if isinstance(self.fields, str):
+            self.fields = (self.fields,)
+        elif isinstance(self.fields, (list, tuple, set)):
+            self.fields = tuple(self.fields)
+        else:
+            raise AlgoliaIndexError('Fields must be a str, list, tuple or set')
+
+    def _init_index(self, client, settings):
+
+        tmp_index_name = '{index_name}_tmp'.format(index_name=self.index_name)
+
+        if 'INDEX_PREFIX' in settings:
+            self.index_name = settings['INDEX_PREFIX'] + '_' + self.index_name
+            tmp_index_name = '{index_prefix}_{tmp_index_name}'.format(
+                tmp_index_name=tmp_index_name,
+                index_prefix=settings['INDEX_PREFIX']
+            )
+        if 'INDEX_SUFFIX' in settings:
+            self.index_name += '_' + settings['INDEX_SUFFIX']
+            tmp_index_name = '{tmp_index_name}_{index_suffix}'.format(
+                tmp_index_name=tmp_index_name,
+                index_suffix=settings['INDEX_SUFFIX']
+            )
+
+        self.__index = client.init_index(self.index_name)
+        self.__tmp_index = client.init_index(tmp_index_name)
+
+    @staticmethod
+    def _validate_geolocation(geolocation):
+        """
+        Make sure we have the proper geolocation format.
+        """
+        if set(geolocation) != {'lat', 'lng'}:
+            raise AlgoliaIndexError(
+                'Invalid geolocation format, requires "lat" and "lng" keys only got {}'.format(
+                    geolocation
+                )
+            )
+
+    def get_raw_record(self, instance, update_fields=None):
+        """
+        Gets the raw record.
+
+        If `update_fields` is set, the raw record will be build with only
+        the objectID and the given fields. Also, `_geoloc` and `_tags` will
+        not be included.
+        """
+        tmp = {'objectID': self.objectID(instance)}
+
+        if update_fields:
+            if isinstance(update_fields, str):
+                update_fields = (update_fields,)
+
+            for elt in update_fields:
+                key = self._translate_fields.get(elt, None)
+                if key:
+                    tmp[key] = self._named_fields[key](instance)
+        else:
+            for key, value in self._named_fields.items():
+                tmp[key] = value(instance)
+
+            if self.geo_field:
+                loc = self.geo_field(instance)
+
+                if isinstance(loc, tuple):
+                    tmp['_geoloc'] = {'lat': loc[0], 'lng': loc[1]}
+                elif isinstance(loc, dict):
+                    self._validate_geolocation(loc)
+                    tmp['_geoloc'] = loc
+                elif isinstance(loc, list):
+                    [self._validate_geolocation(geo) for geo in loc]
+                    tmp['_geoloc'] = loc
+
+            if self.tags:
+                if callable(self.tags):
+                    tmp['_tags'] = self.tags(instance)
+                if not isinstance(tmp['_tags'], list):
+                    tmp['_tags'] = list(tmp['_tags'])
+
+        return tmp
+
+    def _has_should_index(self):
+        """Return True if this AlgoliaIndex has a should_index method or attribute"""
+        return self.should_index is not None
+
+    def _should_index(self, instance):
+        """Return True if the object should be indexed (including when self.should_index is not set)."""
+        if self._has_should_index():
+            return self._should_really_index(instance)
+        else:
+            return True
+
+    def _should_really_index(self, instance):
+        raise NotImplementedError
+
+    def save_record(self, instance, update_fields=None, **kwargs):
+        """Saves the record.
+
+        If `update_fields` is set, this method will use partial_update_object()
+        and will update only the given fields (never `_geoloc` and `_tags`).
+
+        For more information about partial_update_object:
+        https://github.com/algolia/algoliasearch-client-python#update-an-existing-object-in-the-index
+        """
+        if not self._should_index(instance):
+            # Should not index, but since we don't now the state of the
+            # instance, we need to send a DELETE request to ensure that if
+            # the instance was previously indexed, it will be removed.
+            self.delete_record(instance)
+            return
+
+        try:
+            if update_fields:
+                obj = self.get_raw_record(instance,
+                                          update_fields=update_fields)
+                result = self.__index.partial_update_object(obj)
+            else:
+                obj = self.get_raw_record(instance)
+                result = self.__index.save_object(obj)
+            logger.info('SAVE %s FROM %s', obj['objectID'], instance._meta.label)
+            return result
+        except AlgoliaException as e:
+            if DEBUG:
+                raise e
+            else:
+                logger.warning('%s FROM %s NOT SAVED: %s', obj['objectID'],
+                               instance._meta.label, e)
+
+    def delete_record(self, instance):
+        """Deletes the record."""
+        objectID = self.objectID(instance)
+        try:
+            self.__index.delete_object(objectID)
+            logger.info('DELETE %s FROM %s', objectID, instance._meta.label)
+        except AlgoliaException as e:
+            if DEBUG:
+                raise e
+            else:
+                logger.warning('%s FROM %s NOT DELETED: %s', objectID,
+                               instance._meta.label, e)
+
+    def update_records(self, qs, batch_size=1000, **kwargs):
+        """
+        Updates multiple records.
+
+        This method is optimized for speed. It takes a QuerySet and the same
+        arguments as QuerySet.update(). Optionnaly, you can specify the size
+        of the batch send to Algolia with batch_size (default to 1000).
+
+        >>> from algoliasearch_django import update_records
+        >>> qs = MyModel.objects.filter(myField=False)
+        >>> update_records(MyModel, qs, myField=True)
+        >>> qs.update(myField=True)
+        """
+        tmp = {}
+        for key, value in kwargs.items():
+            name = self._translate_fields.get(key, None)
+            if name:
+                tmp[name] = value
+
+        batch = []
+        objectsIDs = qs.only(self.custom_objectID).values_list(
+            self.custom_objectID, flat=True)
+        for elt in objectsIDs:
+            tmp['objectID'] = elt
+            batch.append(dict(tmp))
+
+            if len(batch) >= batch_size:
+                self.__index.partial_update_objects(batch)
+                batch = []
+
+        if len(batch) > 0:
+            self.__index.partial_update_objects(batch)
+
+    def raw_search(self, query='', params=None):
+        """Performs a search query and returns the parsed JSON."""
+        if params is None:
+            params = {}
+
+        try:
+            return self.__index.search(query, params)
+        except AlgoliaException as e:
+            if DEBUG:
+                raise e
+            else:
+                logger.warning('ERROR DURING SEARCH ON %s: %s', self.index_name, e)
+
+    def get_settings(self):
+        """Returns the settings of the index."""
+        try:
+            logger.info('GET SETTINGS ON %s', self.index_name)
+            return self.__index.get_settings()
+        except AlgoliaException as e:
+            if DEBUG:
+                raise e
+            else:
+                logger.warning('ERROR DURING GET_SETTINGS ON %s: %s',
+                               self.index_name, e)
+
+    def set_settings(self):
+        """Applies the settings to the index."""
+        if not self.settings:
+            return
+
+        try:
+            self.__index.set_settings(self.settings)
+            logger.info('APPLY SETTINGS ON %s', self.index_name)
+        except AlgoliaException as e:
+            if DEBUG:
+                raise e
+            else:
+                logger.warning('SETTINGS NOT APPLIED ON %s: %s',
+                               self.index_name, e)
+
+    def clear_index(self):
+        """Clears the index."""
+        try:
+            self.__index.clear_index()
+            logger.info('CLEAR INDEX %s', self.index_name)
+        except AlgoliaException as e:
+            if DEBUG:
+                raise e
+            else:
+                logger.warning('%s NOT CLEARED: %s', self.index_name, e)
+
+    def wait_task(self, task_id):
+        try:
+            self.__index.wait_task(task_id)
+            logger.info('WAIT TASK %s', self.index_name)
+        except AlgoliaException as e:
+            if DEBUG:
+                raise e
+            else:
+                logger.warning('%s NOT WAIT: %s', self.index_name, e)
+
+    def reindex_all(self, batch_size=1000):
+        """
+        Reindex all the records.
+
+        By default, this method use Model.objects.all() but you can implement
+        a method `get_queryset` in your subclass. This can be used to optimize
+        the performance (for example with select_related or prefetch_related).
+        """
+        should_keep_synonyms = False
+        should_keep_rules = False
+        try:
+            if not self.settings:
+                self.settings = self.get_settings()
+                logger.debug('Got settings for index %s: %s', self.index_name, self.settings)
+            else:
+                logger.debug("index %s already has settings: %s", self.index_name, self.settings)
+        except AlgoliaException as e:
+            if any("Index does not exist" in arg for arg in e.args):
+                pass  # Expected, let's clear and recreate from scratch
+            else:
+                raise e  # Unexpected error while getting settings
+        try:
+            if self.settings:
+                replicas = self.settings.get('replicas', None)
+                slaves = self.settings.get('slaves', None)
+
+                should_keep_replicas = replicas is not None
+                should_keep_slaves = slaves is not None
+
+                if should_keep_replicas:
+                    self.settings['replicas'] = []
+                    logger.debug("REMOVE REPLICAS FROM SETTINGS")
+                if should_keep_slaves:
+                    self.settings['slaves'] = []
+                    logger.debug("REMOVE SLAVES FROM SETTINGS")
+
+                self.__tmp_index.wait_task(self.__tmp_index.set_settings(self.settings.copy())['taskID'])
+                logger.debug('APPLY SETTINGS ON %s_tmp', self.index_name)
+            rules = []
+            synonyms = []
+            for r in self.__index.iter_rules():
+                rules.append(r)
+            for s in self.__index.iter_synonyms():
+                synonyms.append(s)
+            if len(rules):
+                logger.debug('Got rules for index %s: %s', self.index_name, rules)
+                should_keep_rules = True
+            if len(synonyms):
+                logger.debug('Got synonyms for index %s: %s', self.index_name, rules)
+                should_keep_synonyms = True
+
+            self.__tmp_index.clear_index()
+            logger.debug('CLEAR INDEX %s_tmp', self.index_name)
+
+            counts = 0
+            batch = []
+
+            for instance in self.get_queryset():
+                if not self._should_index(instance):
+                    continue  # should not index
+
+                batch.append(self.get_raw_record(instance))
+                if len(batch) >= batch_size:
+                    self.__tmp_index.save_objects(batch)
+                    logger.info('SAVE %d OBJECTS TO %s_tmp', len(batch),
+                                self.index_name)
+                    batch = []
+                counts += 1
+            if len(batch) > 0:
+                self.__tmp_index.save_objects(batch)
+                logger.info('SAVE %d OBJECTS TO %s_tmp', len(batch),
+                            self.index_name)
+
+            self.__client.move_index(self.__tmp_index.index_name,
+                                     self.__index.index_name)
+            logger.info('MOVE INDEX %s_tmp TO %s', self.index_name,
+                        self.index_name)
+
+            if self.settings:
+                if should_keep_replicas:
+                    self.settings['replicas'] = replicas
+                    logger.debug("RESTORE REPLICAS")
+                if should_keep_slaves:
+                    self.settings['slaves'] = slaves
+                    logger.debug("RESTORE SLAVES")
+                if should_keep_replicas or should_keep_slaves:
+                    self.__index.set_settings(self.settings)
+                if should_keep_rules:
+                    response = self.__index.batch_rules(rules, forward_to_replicas=True)
+                    self.__index.wait_task(response['taskID'])
+                    logger.info("Saved rules for index %s with response: {}".format(response), self.index_name)
+                if should_keep_synonyms:
+                    response = self.__index.batch_synonyms(synonyms, forward_to_replicas=True)
+                    self.__index.wait_task(response['taskID'])
+                    logger.info("Saved synonyms for index %s with response: {}".format(response), self.index_name)
+            return counts
+        except AlgoliaException as e:
+            if DEBUG:
+                raise e
+            else:
+                logger.warning('ERROR DURING REINDEXING %s: %s', self.index_name,
+                               e)

--- a/algoliasearch_django/models/index.py
+++ b/algoliasearch_django/models/index.py
@@ -9,7 +9,7 @@ import sys
 from algoliasearch.helpers import AlgoliaException
 from django.db.models.query_utils import DeferredAttribute
 
-from .settings import DEBUG
+from ..settings import DEBUG
 
 logger = logging.getLogger(__name__)
 

--- a/algoliasearch_django/models/index.py
+++ b/algoliasearch_django/models/index.py
@@ -4,12 +4,12 @@ import inspect
 from functools import partial
 from itertools import chain
 import logging
-
 import sys
-from algoliasearch.helpers import AlgoliaException
+
 from django.db.models.query_utils import DeferredAttribute
 
-from ..settings import DEBUG
+from .base import BaseAlgoliaIndex, AlgoliaIndexError
+
 
 logger = logging.getLogger(__name__)
 
@@ -34,63 +34,28 @@ def get_model_attr(name):
     return partial(_getattr, name=name)
 
 
-class AlgoliaIndexError(Exception):
-    """Something went wrong with an Algolia Index."""
-
-
-class AlgoliaIndex(object):
+class AlgoliaIndex(BaseAlgoliaIndex):
     """An index in the Algolia backend."""
 
     # Use to specify a custom field that will be used for the objectID.
     # This field should be unique.
     custom_objectID = 'pk'
 
-    # Use to specify the fields that should be included in the index.
-    fields = ()
-
-    # Use to specify the geo-fields that should be used for location search.
-    # The attribute should be a callable that returns a tuple.
-    geo_field = None
-
-    # Use to specify the field that should be used for filtering by tag.
-    tags = None
-
-    # Use to specify the index to target on Algolia.
-    index_name = None
-
-    # Use to specify the settings of the index.
-    settings = None
-
-    # Used to specify if the instance should be indexed.
-    # The attribute should be either:
-    # - a callable that returns a boolean.
-    # - a BooleanField
-    # - a boolean property or attribute
-    should_index = None
-
     # Name of the attribute to check on instances if should_index is not a callable
     _should_index_is_method = False
 
     def __init__(self, model, client, settings):
         """Initializes the index."""
-        self.__init_index(client, model, settings)
+        if not self.index_name:
+            self.index_name = model.__name__
+
+        self._init_index(client, settings)
+
+        super(AlgoliaIndex, self).__init__(client, settings)
 
         self.model = model
-        self.__client = client
-        self.__named_fields = {}
-        self.__translate_fields = {}
-
-        if self.settings is None:  # Only set settings if the actual index class does not define some
-            self.settings = {}
 
         all_model_fields = [f.name for f in model._meta.get_fields() if not f.is_relation]
-
-        if isinstance(self.fields, str):
-            self.fields = (self.fields,)
-        elif isinstance(self.fields, (list, tuple, set)):
-            self.fields = tuple(self.fields)
-        else:
-            raise AlgoliaIndexError('Fields must be a str, list, tuple or set')
 
         # Check fields
         for field in self.fields:
@@ -106,11 +71,11 @@ class AlgoliaIndex(object):
                 raise AlgoliaIndexError(
                     'Invalid fields syntax: {} (type: {})'.format(field, type(field)))
 
-            self.__translate_fields[attr] = name
+            self._translate_fields[attr] = name
             if attr in all_model_fields:
-                self.__named_fields[name] = get_model_attr(attr)
+                self._named_fields[name] = get_model_attr(attr)
             else:
-                self.__named_fields[name] = check_and_get_attr(model, attr)
+                self._named_fields[name] = check_and_get_attr(model, attr)
 
         # If no fields are specified, index all the fields of the model
         if not self.fields:
@@ -120,8 +85,8 @@ class AlgoliaIndex(object):
                     self.fields.remove(elt)
                 except KeyError:
                     continue
-            self.__translate_fields = dict(zip(self.fields, self.fields))
-            self.__named_fields = dict(zip(self.fields, map(get_model_attr,
+            self._translate_fields = dict(zip(self.fields, self.fields))
+            self._named_fields = dict(zip(self.fields, map(get_model_attr,
                                                             self.fields)))
 
         # Check custom_objectID
@@ -157,93 +122,13 @@ class AlgoliaIndex(object):
                     raise AlgoliaIndexError('{} is not an attribute nor a field of {}.'.format(
                         self.should_index, model))
 
-    def __init_index(self, client, model, settings):
-        if not self.index_name:
-            self.index_name = model.__name__
-
-        tmp_index_name = '{index_name}_tmp'.format(index_name=self.index_name)
-
-        if 'INDEX_PREFIX' in settings:
-            self.index_name = settings['INDEX_PREFIX'] + '_' + self.index_name
-            tmp_index_name = '{index_prefix}_{tmp_index_name}'.format(
-                tmp_index_name=tmp_index_name,
-                index_prefix=settings['INDEX_PREFIX']
-            )
-        if 'INDEX_SUFFIX' in settings:
-            self.index_name += '_' + settings['INDEX_SUFFIX']
-            tmp_index_name = '{tmp_index_name}_{index_suffix}'.format(
-                tmp_index_name=tmp_index_name,
-                index_suffix=settings['INDEX_SUFFIX']
-            )
-
-        self.__index = client.init_index(self.index_name)
-        self.__tmp_index = client.init_index(tmp_index_name)
-
-    @staticmethod
-    def _validate_geolocation(geolocation):
-        """
-        Make sure we have the proper geolocation format.
-        """
-        if set(geolocation) != {'lat', 'lng'}:
-            raise AlgoliaIndexError(
-                'Invalid geolocation format, requires "lat" and "lng" keys only got {}'.format(
-                    geolocation
-                )
-            )
+    def get_queryset(self):
+        return self.model.objects.all()
 
     def get_raw_record(self, instance, update_fields=None):
-        """
-        Gets the raw record.
-
-        If `update_fields` is set, the raw record will be build with only
-        the objectID and the given fields. Also, `_geoloc` and `_tags` will
-        not be included.
-        """
-        tmp = {'objectID': self.objectID(instance)}
-
-        if update_fields:
-            if isinstance(update_fields, str):
-                update_fields = (update_fields,)
-
-            for elt in update_fields:
-                key = self.__translate_fields.get(elt, None)
-                if key:
-                    tmp[key] = self.__named_fields[key](instance)
-        else:
-            for key, value in self.__named_fields.items():
-                tmp[key] = value(instance)
-
-            if self.geo_field:
-                loc = self.geo_field(instance)
-
-                if isinstance(loc, tuple):
-                    tmp['_geoloc'] = {'lat': loc[0], 'lng': loc[1]}
-                elif isinstance(loc, dict):
-                    self._validate_geolocation(loc)
-                    tmp['_geoloc'] = loc
-                elif isinstance(loc, list):
-                    [self._validate_geolocation(geo) for geo in loc]
-                    tmp['_geoloc'] = loc
-
-            if self.tags:
-                if callable(self.tags):
-                    tmp['_tags'] = self.tags(instance)
-                if not isinstance(tmp['_tags'], list):
-                    tmp['_tags'] = list(tmp['_tags'])
-
+        tmp = super(AlgoliaIndex, self).get_raw_record(instance, update_fields)
         logger.debug('BUILD %s FROM %s', tmp['objectID'], self.model)
         return tmp
-
-    def _has_should_index(self):
-        """Return True if this AlgoliaIndex has a should_index method or attribute"""
-        return self.should_index is not None
-
-    def _should_index(self, instance):
-        """Return True if the object should be indexed (including when self.should_index is not set)."""
-        if self._has_should_index():
-            return self._should_really_index(instance)
-        else:
-            return True
 
     def _should_really_index(self, instance):
         """Return True if according to should_index the object should be indexed."""
@@ -277,251 +162,3 @@ class AlgoliaIndex(object):
                 raise AlgoliaIndexError("%s's should_index (%s) should be a boolean" % (
                     instance.__class__.__name__, self.should_index))
             return attr_value
-
-    def save_record(self, instance, update_fields=None, **kwargs):
-        """Saves the record.
-
-        If `update_fields` is set, this method will use partial_update_object()
-        and will update only the given fields (never `_geoloc` and `_tags`).
-
-        For more information about partial_update_object:
-        https://github.com/algolia/algoliasearch-client-python#update-an-existing-object-in-the-index
-        """
-        if not self._should_index(instance):
-            # Should not index, but since we don't now the state of the
-            # instance, we need to send a DELETE request to ensure that if
-            # the instance was previously indexed, it will be removed.
-            self.delete_record(instance)
-            return
-
-        try:
-            if update_fields:
-                obj = self.get_raw_record(instance,
-                                          update_fields=update_fields)
-                result = self.__index.partial_update_object(obj)
-            else:
-                obj = self.get_raw_record(instance)
-                result = self.__index.save_object(obj)
-            logger.info('SAVE %s FROM %s', obj['objectID'], self.model)
-            return result
-        except AlgoliaException as e:
-            if DEBUG:
-                raise e
-            else:
-                logger.warning('%s FROM %s NOT SAVED: %s', obj['objectID'],
-                               self.model, e)
-
-    def delete_record(self, instance):
-        """Deletes the record."""
-        objectID = self.objectID(instance)
-        try:
-            self.__index.delete_object(objectID)
-            logger.info('DELETE %s FROM %s', objectID, self.model)
-        except AlgoliaException as e:
-            if DEBUG:
-                raise e
-            else:
-                logger.warning('%s FROM %s NOT DELETED: %s', objectID,
-                               self.model, e)
-
-    def update_records(self, qs, batch_size=1000, **kwargs):
-        """
-        Updates multiple records.
-
-        This method is optimized for speed. It takes a QuerySet and the same
-        arguments as QuerySet.update(). Optionnaly, you can specify the size
-        of the batch send to Algolia with batch_size (default to 1000).
-
-        >>> from algoliasearch_django import update_records
-        >>> qs = MyModel.objects.filter(myField=False)
-        >>> update_records(MyModel, qs, myField=True)
-        >>> qs.update(myField=True)
-        """
-        tmp = {}
-        for key, value in kwargs.items():
-            name = self.__translate_fields.get(key, None)
-            if name:
-                tmp[name] = value
-
-        batch = []
-        objectsIDs = qs.only(self.custom_objectID).values_list(
-            self.custom_objectID, flat=True)
-        for elt in objectsIDs:
-            tmp['objectID'] = elt
-            batch.append(dict(tmp))
-
-            if len(batch) >= batch_size:
-                self.__index.partial_update_objects(batch)
-                batch = []
-
-        if len(batch) > 0:
-            self.__index.partial_update_objects(batch)
-
-    def raw_search(self, query='', params=None):
-        """Performs a search query and returns the parsed JSON."""
-        if params is None:
-            params = {}
-
-        try:
-            return self.__index.search(query, params)
-        except AlgoliaException as e:
-            if DEBUG:
-                raise e
-            else:
-                logger.warning('ERROR DURING SEARCH ON %s: %s', self.index_name, e)
-
-    def get_settings(self):
-        """Returns the settings of the index."""
-        try:
-            logger.info('GET SETTINGS ON %s', self.index_name)
-            return self.__index.get_settings()
-        except AlgoliaException as e:
-            if DEBUG:
-                raise e
-            else:
-                logger.warning('ERROR DURING GET_SETTINGS ON %s: %s',
-                               self.model, e)
-
-    def set_settings(self):
-        """Applies the settings to the index."""
-        if not self.settings:
-            return
-
-        try:
-            self.__index.set_settings(self.settings)
-            logger.info('APPLY SETTINGS ON %s', self.index_name)
-        except AlgoliaException as e:
-            if DEBUG:
-                raise e
-            else:
-                logger.warning('SETTINGS NOT APPLIED ON %s: %s',
-                               self.model, e)
-
-    def clear_index(self):
-        """Clears the index."""
-        try:
-            self.__index.clear_index()
-            logger.info('CLEAR INDEX %s', self.index_name)
-        except AlgoliaException as e:
-            if DEBUG:
-                raise e
-            else:
-                logger.warning('%s NOT CLEARED: %s', self.model, e)
-
-    def wait_task(self, task_id):
-        try:
-            self.__index.wait_task(task_id)
-            logger.info('WAIT TASK %s', self.index_name)
-        except AlgoliaException as e:
-            if DEBUG:
-                raise e
-            else:
-                logger.warning('%s NOT WAIT: %s', self.model, e)
-
-    def reindex_all(self, batch_size=1000):
-        """
-        Reindex all the records.
-
-        By default, this method use Model.objects.all() but you can implement
-        a method `get_queryset` in your subclass. This can be used to optimize
-        the performance (for example with select_related or prefetch_related).
-        """
-        should_keep_synonyms = False
-        should_keep_rules = False
-        try:
-            if not self.settings:
-                self.settings = self.get_settings()
-                logger.debug('Got settings for index %s: %s', self.index_name, self.settings)
-            else:
-                logger.debug("index %s already has settings: %s", self.index_name, self.settings)
-        except AlgoliaException as e:
-            if any("Index does not exist" in arg for arg in e.args):
-                pass  # Expected, let's clear and recreate from scratch
-            else:
-                raise e  # Unexpected error while getting settings
-        try:
-            if self.settings:
-                replicas = self.settings.get('replicas', None)
-                slaves = self.settings.get('slaves', None)
-
-                should_keep_replicas = replicas is not None
-                should_keep_slaves = slaves is not None
-
-                if should_keep_replicas:
-                    self.settings['replicas'] = []
-                    logger.debug("REMOVE REPLICAS FROM SETTINGS")
-                if should_keep_slaves:
-                    self.settings['slaves'] = []
-                    logger.debug("REMOVE SLAVES FROM SETTINGS")
-
-                self.__tmp_index.wait_task(self.__tmp_index.set_settings(self.settings.copy())['taskID'])
-                logger.debug('APPLY SETTINGS ON %s_tmp', self.index_name)
-            rules = []
-            synonyms = []
-            for r in self.__index.iter_rules():
-                rules.append(r)
-            for s in self.__index.iter_synonyms():
-                synonyms.append(s)
-            if len(rules):
-                logger.debug('Got rules for index %s: %s', self.index_name, rules)
-                should_keep_rules = True
-            if len(synonyms):
-                logger.debug('Got synonyms for index %s: %s', self.index_name, rules)
-                should_keep_synonyms = True
-
-            self.__tmp_index.clear_index()
-            logger.debug('CLEAR INDEX %s_tmp', self.index_name)
-
-            counts = 0
-            batch = []
-
-            if hasattr(self, 'get_queryset'):
-                qs = self.get_queryset()
-            else:
-                qs = self.model.objects.all()
-
-            for instance in qs:
-                if not self._should_index(instance):
-                    continue  # should not index
-
-                batch.append(self.get_raw_record(instance))
-                if len(batch) >= batch_size:
-                    self.__tmp_index.save_objects(batch)
-                    logger.info('SAVE %d OBJECTS TO %s_tmp', len(batch),
-                                self.index_name)
-                    batch = []
-                counts += 1
-            if len(batch) > 0:
-                self.__tmp_index.save_objects(batch)
-                logger.info('SAVE %d OBJECTS TO %s_tmp', len(batch),
-                            self.index_name)
-
-            self.__client.move_index(self.__tmp_index.index_name,
-                                     self.__index.index_name)
-            logger.info('MOVE INDEX %s_tmp TO %s', self.index_name,
-                        self.index_name)
-
-            if self.settings:
-                if should_keep_replicas:
-                    self.settings['replicas'] = replicas
-                    logger.debug("RESTORE REPLICAS")
-                if should_keep_slaves:
-                    self.settings['slaves'] = slaves
-                    logger.debug("RESTORE SLAVES")
-                if should_keep_replicas or should_keep_slaves:
-                    self.__index.set_settings(self.settings)
-                if should_keep_rules:
-                    response = self.__index.batch_rules(rules, forward_to_replicas=True)
-                    self.__index.wait_task(response['taskID'])
-                    logger.info("Saved rules for index %s with response: {}".format(response), self.index_name)
-                if should_keep_synonyms:
-                    response = self.__index.batch_synonyms(synonyms, forward_to_replicas=True)
-                    self.__index.wait_task(response['taskID'])
-                    logger.info("Saved synonyms for index %s with response: {}".format(response), self.index_name)
-            return counts
-        except AlgoliaException as e:
-            if DEBUG:
-                raise e
-            else:
-                logger.warning('ERROR DURING REINDEXING %s: %s', self.model,
-                               e)


### PR DESCRIPTION
This PR lays the groundwork for supporting multiple types of algolia index, ahead of introducing the multi-model-index feature.

* I've turned `models.py` into a package, for extensibility. The documentation suggests importing `AlgoliaIndex` from the top level package, so I don't think this is a problem.
* I've split `AlgoliaIndex` into a base class which handles the core functionality, and a subclass which handles interaction with the single registered model class.

There's a small change in behaviour in the content of the log messages — instead of printing `self.model` we now use `instance._meta.label` when dealing with instances, and `self.index_name` when dealing with indexes.

