### PR TITLE
Aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ You can find the full reference on [Algolia's website](https://www.algolia.com/d
     * [Multiple indices per model](#multiple-indices-per-model)
     * [Temporarily disable the auto-indexing](#temporarily-disable-the-auto-indexing)
 
+1. **[Aggregators](#aggregators)**
+    * [Aggregators](#aggregators)
+
 1. **[Tests](#tests)**
     * [Run Tests](#run-tests)
 
@@ -396,7 +399,28 @@ with disable_auto_indexing(MyModel):
 
 ```
 
+# Aggregators
 
+Aggregators allow multiple models to be included in a single index.
+
+```python
+import algoliasearch_django as algoliasearch
+models = [...]
+algoliasearch.register_aggregator(models)
+```
+
+For more control, `Aggregator` can be subclassed in the same way as `AlgoliaIndex`:
+
+```py
+from algoliasearch_django import Aggregator
+
+class CustomAggregator(Aggregator)
+    index_name = "MyAggregatorIndex"
+    ...
+
+models = [...]
+algoliasearch.register_aggregator(models, CustomAggregator)
+```
 
 # Tests
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ class YourModelIndex(AlgoliaIndex):
 ## Commands
 
 * `python manage.py algolia_reindex`: reindex all the registered models. This command will first send all the record to a temporary index and then moves it.
-    * you can pass ``--model`` parameter to reindex a given model
+    * you can pass ``--index`` parameter to reindex a given index
 * `python manage.py algolia_applysettings`: (re)apply the index settings.
 * `python manage.py algolia_clearindex`: clear the index
 

--- a/algoliasearch_django/__init__.py
+++ b/algoliasearch_django/__init__.py
@@ -14,8 +14,10 @@ __version__ = version.VERSION
 ALGOLIA_SETTINGS = settings.SETTINGS
 
 AlgoliaIndex = models.AlgoliaIndex
+Aggregator = models.Aggregator
 AlgoliaEngine = registration.AlgoliaEngine
 algolia_engine = registration.algolia_engine
+
 
 # Algolia Engine functions
 

--- a/algoliasearch_django/__init__.py
+++ b/algoliasearch_django/__init__.py
@@ -22,6 +22,7 @@ algolia_engine = registration.algolia_engine
 # Algolia Engine functions
 
 register = algolia_engine.register
+register_aggregator = algolia_engine.register_aggregator
 unregister = algolia_engine.unregister
 get_registered_model = algolia_engine.get_registered_models
 

--- a/algoliasearch_django/__init__.py
+++ b/algoliasearch_django/__init__.py
@@ -26,6 +26,7 @@ register_aggregator = algolia_engine.register_aggregator
 unregister = algolia_engine.unregister
 get_registered_model = algolia_engine.get_registered_models
 
+get_registered_adapters = algolia_engine.get_registered_adapters
 get_adapter = algolia_engine.get_adapter
 get_adapter_from_instance = algolia_engine.get_adapter_from_instance
 

--- a/algoliasearch_django/management/commands/algolia_applysettings.py
+++ b/algoliasearch_django/management/commands/algolia_applysettings.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 
-from algoliasearch_django import get_registered_model
+from algoliasearch_django import get_registered_adapters
 from algoliasearch_django import get_adapter
 
 
@@ -8,15 +8,15 @@ class Command(BaseCommand):
     help = 'Apply index settings.'
 
     def add_arguments(self, parser):
-        parser.add_argument('--model', nargs='+', type=str)
+        parser.add_argument('--index', nargs='+', type=str)
 
     def handle(self, *args, **options):
         """Run the management command."""
         self.stdout.write('Apply settings to index:')
-        for model in get_registered_model():
-            if options.get('model', None) and not (model.__name__ in
-                                                   options['model']):
-                continue
+        for adapter in get_registered_adapters():
+            if options.get('index', None) is not None:
+                if (adapter.index_name not in options['index']):
+                    continue
 
-            get_adapter(model).set_settings()
-            self.stdout.write('\t* {}'.format(model.__name__))
+            adapter.set_settings()
+            self.stdout.write('\t* {}'.format(adapter.index_name))

--- a/algoliasearch_django/management/commands/algolia_clearindex.py
+++ b/algoliasearch_django/management/commands/algolia_clearindex.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 
-from algoliasearch_django import get_registered_model
+from algoliasearch_django import get_registered_adapters
 from algoliasearch_django import clear_index
 
 
@@ -8,15 +8,15 @@ class Command(BaseCommand):
     help = 'Clear index.'
 
     def add_arguments(self, parser):
-        parser.add_argument('--model', nargs='+', type=str)
+        parser.add_argument('--index', nargs='+', type=str)
 
     def handle(self, *args, **options):
         """Run the management command."""
         self.stdout.write('Clear index:')
-        for model in get_registered_model():
-            if options.get('model', None) and not (model.__name__ in
-                                                   options['model']):
-                continue
+        for adapter in get_registered_adapters():
+            if options.get('index', None) is not None:
+                if (adapter.index_name not in options['index']):
+                    continue
 
-            clear_index(model)
-            self.stdout.write('\t* {}'.format(model.__name__))
+            adapter.clear_index()
+            self.stdout.write('\t* {}'.format(adapter.index_name))

--- a/algoliasearch_django/management/commands/algolia_reindex.py
+++ b/algoliasearch_django/management/commands/algolia_reindex.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 
-from algoliasearch_django import get_registered_model
+from algoliasearch_django import get_registered_adapters
 from algoliasearch_django import reindex_all
 
 
@@ -9,7 +9,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('--batchsize', nargs='?', default=1000, type=int)
-        parser.add_argument('--model', nargs='+', type=str)
+        parser.add_argument('--index', nargs='+', type=str)
 
     def handle(self, *args, **options):
         """Run the management command."""
@@ -19,11 +19,12 @@ class Command(BaseCommand):
             # the value, instead of not be present in the dict
             batch_size = 1000
 
-        self.stdout.write('The following models were reindexed:')
-        for model in get_registered_model():
-            if options.get('model', None) and not (model.__name__ in
-                                                   options['model']):
-                continue
+        self.stdout.write('The following indexes were reindexed:')
 
-            counts = reindex_all(model, batch_size=batch_size)
-            self.stdout.write('\t* {} --> {}'.format(model.__name__, counts))
+        for adapter in get_registered_adapters():
+            if options.get('index', None) is not None:
+                if (adapter.index_name not in options['index']):
+                    continue
+
+            counts = adapter.reindex_all(batch_size=batch_size)
+            self.stdout.write('\t* {} --> {}'.format(adapter.index_name, counts))

--- a/algoliasearch_django/models/__init__.py
+++ b/algoliasearch_django/models/__init__.py
@@ -1,2 +1,3 @@
 from .base import AlgoliaIndexError
 from .index import AlgoliaIndex
+from .aggregator import Aggregator

--- a/algoliasearch_django/models/aggregator.py
+++ b/algoliasearch_django/models/aggregator.py
@@ -1,0 +1,109 @@
+from __future__ import unicode_literals
+
+import sys
+
+from functools import partial
+from itertools import chain
+
+from .base import BaseAlgoliaIndex, AlgoliaIndexError
+
+
+def _getattr(obj, name):
+    attr = getattr(obj, name, "")
+    if callable(attr):
+        return attr()
+    else:
+        return attr
+
+
+def get_model_attr(name):
+    return partial(_getattr, name=name)
+
+
+class Aggregator(BaseAlgoliaIndex):
+
+    custom_objectID = None
+
+    def __init__(self, models, client, settings):
+        if not self.index_name:
+            self.index_name = type(self).__name__
+
+        self._init_index(client, settings)
+
+        super(Aggregator, self).__init__(client, settings)
+
+        self.models = models
+        all_model_fields = chain.from_iterable(
+                [f.name for f in model._meta.get_fields() if not f.is_relation]
+                for model in self.models)
+
+        # Check fields
+        for field in self.fields:
+            # unicode is a type in python < 3.0, which we need to support (e.g. dev uses unicode_literals)
+            # noinspection PyUnresolvedReferences
+            if sys.version_info < (3, 0) and isinstance(field, unicode) or isinstance(field, str):
+                attr = field
+                name = field
+            elif isinstance(field, (list, tuple)) and len(field) == 2:
+                attr = field[0]
+                name = field[1]
+            else:
+                raise AlgoliaIndexError(
+                    'Invalid fields syntax: {} (type: {})'.format(field, type(field)))
+
+            self._translate_fields[attr] = name
+            self._named_fields[name] = get_model_attr(attr)
+
+        # If no fields are specified, index all the fields of the model
+        if not self.fields:
+            self.fields = set(all_model_fields)
+            for elt in ('pk', 'id', 'objectID'):
+                try:
+                    self.fields.remove(elt)
+                except KeyError:
+                    continue
+            self._translate_fields = dict(zip(self.fields, self.fields))
+            self._named_fields = dict(zip(self.fields, map(get_model_attr,
+                                                            self.fields)))
+
+        # Keep track of object model for easy faceting
+        self._named_fields['_objectModel'] = self._model_name
+
+        # Check custom_objectID
+        if self.custom_objectID:
+            self.custom_objectID = get_model_attr(self.custom_objectID)
+
+        # Check tags
+        if self.tags:
+            self.tags = get_model_attr(self.tags)
+
+        # Check geo_field
+        if self.geo_field:
+            self.geo_field = get_model_attr(self.geo_field)
+
+        # Check should_index + get the callable or attribute/field name
+        if self.should_index:
+            self.should_index = get_model_attr(self.should_index)
+
+    def _should_really_index(self, instance):
+        """Return True if according to should_index the object should be indexed."""
+        should_index = self.should_index(instance)
+        if type(should_index) is not bool:
+            raise AlgoliaIndexError("%s's should_index (%s) should be a boolean" % (
+                instance.__class__.__name__, should_index))
+        return should_index
+
+    @staticmethod
+    def _model_name(instance):
+        return instance._meta.label
+
+    def objectID(self, instance):
+        if self.custom_objectID:
+            return self.custom_objectID(instance)
+        else:
+            return "{}:{}".format(self._model_name(instance), instance.pk)
+
+    def get_queryset(self):
+        # This is not really a queryset, but behaves enough like one for reindex_all.
+        return chain.from_iterable(model.objects.all() for model in self.models)
+

--- a/algoliasearch_django/registration.py
+++ b/algoliasearch_django/registration.py
@@ -38,6 +38,8 @@ class AlgoliaEngine(object):
         self.__settings = settings
 
         self.__registered_models = {}
+        self.__registered_adapters = []
+
         self.client = algoliasearch.Client(app_id, api_key)
         self.client.set_extra_header('User-Agent',
                                      'Algolia for Python (%s); Python (%s); Algolia for Django (%s); Django (%s)'
@@ -65,6 +67,7 @@ class AlgoliaEngine(object):
                 '{} should be a subclass of AlgoliaIndex'.format(index_cls))
         index_obj = index_cls(model, self.client, self.__settings)
         self.__registered_models[model] = index_obj
+        self.__registered_adapters.append(index_obj)
 
         if (isinstance(auto_indexing, bool) and
                 auto_indexing) or self.__auto_indexing:
@@ -86,6 +89,7 @@ class AlgoliaEngine(object):
                 '{} should be a subclass of Aggregator'.format(index_cls))
 
         index_obj = index_cls(models, self.client, self.__settings)
+        self.__registered_adapters.append(index_obj)
 
         for model in models:
             self.__registered_models[model] = index_obj
@@ -95,7 +99,6 @@ class AlgoliaEngine(object):
                 post_save.connect(self.__post_save_receiver, model)
                 pre_delete.connect(self.__pre_delete_receiver, model)
                 logger.info('REGISTER %s', model)
-
 
     def unregister(self, model):
         """
@@ -121,6 +124,13 @@ class AlgoliaEngine(object):
         engine.
         """
         return list(self.__registered_models.keys())
+
+    def get_registered_adapters(self):
+        """
+        Returns a list of adapters that have been registered with Algolia
+        engine.
+        """
+        return self.__registered_adapters
 
     def get_adapter(self, model):
         """Returns the adapter associated with the given model."""

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -1,0 +1,207 @@
+from mock import patch, MagicMock
+
+from django.conf import settings
+from django.test import TestCase
+
+from algoliasearch_django import Aggregator
+from algoliasearch_django import algolia_engine
+from algoliasearch_django.models import AlgoliaIndexError
+
+from .models import Website, Example, User
+from .factories import WebsiteFactory, ExampleFactory, UserFactory
+
+
+class AggregatorTestCase(TestCase):
+
+    def setUp(self):
+        self.client = MagicMock()
+
+    def test_default_index_name(self):
+        index = Aggregator([], self.client, settings.ALGOLIA)
+        self.assertEqual(index.index_name, "test_Aggregator_django")
+
+    def test_fields(self):
+        index = Aggregator([Website, Example], self.client, settings.ALGOLIA)
+        self.assertEqual(index.fields, {'name', 'url', 'is_online', 'lng', 'is_admin', 'address',  'lat', 'uid'})
+
+    @patch.object(algolia_engine, "save_record")
+    def test_object_id(self, _):
+        index = Aggregator([Website], self.client, settings.ALGOLIA)
+        website = WebsiteFactory()
+        self.assertEqual(index.objectID(website), "tests.Website:1")
+
+    @patch.object(algolia_engine, "save_record")
+    def test_search(self, _):
+        mock_results = {
+            "hits": [{
+                "objectID": "web.Job:951",
+                "_objectModel": "web.Job"
+            }]
+        }
+        self.client.init_index.return_value.search.return_value = mock_results
+
+        index = Aggregator([Website], self.client, settings.ALGOLIA)
+        results = index.raw_search('example')
+        self.assertDictEqual(results, mock_results)
+
+    @patch.object(algolia_engine, "save_record")
+    def test_get_raw_record(self, _):
+        index = Aggregator([Website, Example], self.client, settings.ALGOLIA)
+        website = WebsiteFactory()
+        record = index.get_raw_record(website)
+        self.assertEqual(record['objectID'], "tests.Website:1")
+        self.assertEqual(record['_objectModel'], "tests.Website")
+        self.assertEqual(record['address'], "")
+
+    @patch.object(algolia_engine, "save_record")
+    def test_get_raw_record_explicit_fields(self, _):
+        class CustomAggregator(Aggregator):
+            fields = ("name", "url", "has_name", "property_string")
+        index = CustomAggregator([Website, Example], self.client, settings.ALGOLIA)
+        example = ExampleFactory(name="example")
+        record = index.get_raw_record(example)
+        self.assertEqual(record['objectID'], "tests.Example:1")
+        self.assertEqual(record['_objectModel'], "tests.Example")
+        self.assertEqual(record['property_string'], "foo")
+        self.assertTrue(record['has_name'])
+
+    @patch.object(algolia_engine, "save_record")
+    def test_should_index_attr(self, _):
+        class CustomAggregator(Aggregator):
+            should_index = "index_me"
+        index = CustomAggregator([Website, Example], self.client, settings.ALGOLIA)
+        example = ExampleFactory()
+        self.assertTrue(index._should_index(example))
+        example.index_me = False
+        self.assertFalse(index._should_index(example))
+
+    @patch.object(algolia_engine, "save_record")
+    def test_should_index_unbound(self, _):
+        class ShouldIndexAggregator(Aggregator):
+            fields = 'name'
+            should_index = 'static_should_index'
+
+        index = ShouldIndexAggregator([Website, Example], self.client, settings.ALGOLIA)
+        example = ExampleFactory()
+        self.assertTrue(index._should_index(example))
+
+        class ShouldNotIndexAggregator(Aggregator):
+            fields = 'name'
+            should_index = 'static_should_not_index'
+
+        index = ShouldNotIndexAggregator([Website, Example], self.client, settings.ALGOLIA)
+        self.assertFalse(index._should_index(example))
+
+    def test_should_index_method(self):
+        class ShouldIndexAggregator(Aggregator):
+            fields = 'name'
+            should_index = 'has_name'
+
+        index = ShouldIndexAggregator([Website, Example], self.client, settings.ALGOLIA)
+        example = ExampleFactory()
+        self.assertTrue(index._should_index(example))
+
+        example.name = None
+        self.assertFalse(index._should_index(example))
+
+    def test_should_index_field(self):
+        class ShouldIndexAggregator(Aggregator):
+            fields = 'name'
+            should_index = 'is_admin'
+
+        index = ShouldIndexAggregator([Website, Example], self.client, settings.ALGOLIA)
+        example = ExampleFactory(is_admin=True)
+        self.assertTrue(index._should_index(example))
+
+        example.is_admin = False
+        self.assertFalse(index._should_index(example))
+
+        class IncorrectShouldIndexAggregator(Aggregator):
+            fields = 'name'
+            should_index = 'name'
+
+        index = IncorrectShouldIndexAggregator([Website, Example], self.client, settings.ALGOLIA)
+        example = ExampleFactory(name="text")
+        with self.assertRaises(AlgoliaIndexError, msg="We should raise when the should_index field is not boolean"):
+            index._should_index(example)
+
+    def test_should_index_property(self):
+
+        class PropertyShouldIndexAggregator(Aggregator):
+            fields = 'name'
+            should_index = 'property_should_index'
+
+        index = PropertyShouldIndexAggregator([Website, Example], self.client, settings.ALGOLIA)
+        example = ExampleFactory()
+        self.assertTrue(index._should_index(example))
+
+        class PropertyShouldNotIndexAggregator(Aggregator):
+            fields = 'name'
+            should_index = 'property_should_not_index'
+
+        index = PropertyShouldNotIndexAggregator([Website, Example], self.client, settings.ALGOLIA)
+        self.assertFalse(index._should_index(example))
+
+        class PropertyStringShouldIndexAggregator(Aggregator):
+            fields = 'name'
+            should_index = 'property_string'
+
+        index = PropertyStringShouldIndexAggregator([Website, Example], self.client, settings.ALGOLIA)
+        with self.assertRaises(AlgoliaIndexError, msg="We should raise when the should_index property is not boolean"):
+            index._should_index(example)
+
+    def test_geo_fields(self):
+        class CustomAggregator(Aggregator):
+            geo_field = 'location'
+
+        index = CustomAggregator([Website, Example], self.client, settings.ALGOLIA)
+        example = ExampleFactory(lat=123, lng=-42.24)
+        self.assertTrue(index._should_index(example))
+        obj = index.get_raw_record(example)
+        self.assertEqual(obj['_geoloc'], {'lat': 123, 'lng': -42.24})
+
+    def test_several_geo_fields(self):
+        class CustomAggregator(Aggregator):
+            geo_field = 'geolocations'
+
+        index = CustomAggregator([Website, Example], self.client, settings.ALGOLIA)
+        example = ExampleFactory()
+        example.locations = [
+            {'lat': 10.3, 'lng': -20.0},
+            {'lat': 22.3, 'lng': 10.0},
+        ]
+        obj = index.get_raw_record(example)
+        self.assertEqual(obj['_geoloc'], [
+            {'lat': 10.3, 'lng': -20.0},
+            {'lat': 22.3, 'lng': 10.0},
+        ])
+
+    @patch.object(algolia_engine, "save_record")
+    def test_tags(self, _):
+        class CustomAggregator(Aggregator):
+            tags = 'permissions'
+
+        index = CustomAggregator([Website, Example], self.client, settings.ALGOLIA)
+
+        # Test the users' tag individually
+        user = UserFactory(_permissions='read,write,admin')
+        obj = index.get_raw_record(user)
+        self.assertListEqual(obj['_tags'], ['read', 'write', 'admin'])
+
+    @patch.object(algolia_engine, "save_record")
+    def test_custom_objectID(self, _):
+        class CustomAggregator(Aggregator):
+            custom_objectID = 'username'
+
+        index = CustomAggregator([Website, User], self.client, settings.ALGOLIA)
+        obj = index.get_raw_record(UserFactory(username="algolia"))
+        self.assertEqual(obj['objectID'], 'algolia')
+
+    @patch.object(algolia_engine, "save_record")
+    def test_custom_objectID_property(self, _):
+        class CustomAggregator(Aggregator):
+            custom_objectID = 'reverse_username'
+
+        index = CustomAggregator([Website, User], self.client, settings.ALGOLIA)
+        obj = index.get_raw_record(UserFactory(username="algolia"))
+        self.assertEqual(obj['objectID'], 'ailogla')

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -105,3 +105,10 @@ class EngineTestCase(TestCase):
 
         with self.assertRaises(RegistrationError):
             self.engine.unregister(Website)
+
+    def test_register_aggregator(self):
+        self.engine.register_aggregator([Website, User])
+        self.assertIn(Website, self.engine.get_registered_models())
+        self.assertIn(User, self.engine.get_registered_models())
+        with self.assertRaises(RegistrationError):
+            self.engine.register(Website)


### PR DESCRIPTION
Adds Aggregator feature, which allows multiple models to be included in a single index. The term Aggregator has previously been used in the PHP SDKs [[1]](https://www.algolia.com/doc/framework-integration/symfony/advanced-use-cases/multiple-models-in-one-index/?language=php) [[2]](https://www.algolia.com/doc/framework-integration/laravel/advanced-use-cases/multiple-models-in-one-index/?language=php).

Since there is no-longer a one-to-one relationship between models and indexes, the management commands have been adjusted to iterate over indexes, rather than models.