### PR TITLE
Fixed syntax error and corrected name of exposed function

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,9 @@
 
 CHANGELOG
 
+2020-08-04 2.0.3
+  * [FIX] Fixed syntax error and corrected name of exposed function (#12)
+
 2020-08-04 2.0.2
   * [FIX] Add Django 3.1 to test matrix (#11)
 

--- a/algoliasearch_django/__init__.py
+++ b/algoliasearch_django/__init__.py
@@ -24,7 +24,8 @@ algolia_engine = registration.algolia_engine
 register = algolia_engine.register
 register_aggregator = algolia_engine.register_aggregator
 unregister = algolia_engine.unregister
-get_registered_model = algolia_engine.get_registered_models
+get_registered_model = algolia_engine.get_registered_models  # Deprecated
+get_registered_models = algolia_engine.get_registered_models
 
 get_registered_adapters = algolia_engine.get_registered_adapters
 get_adapter = algolia_engine.get_adapter

--- a/algoliasearch_django/models/index.py
+++ b/algoliasearch_django/models/index.py
@@ -132,13 +132,9 @@ class AlgoliaIndex(BaseAlgoliaIndex):
         """Return True if according to should_index the object should be indexed."""
         if self._should_index_is_method:
             is_method = inspect.ismethod(self.should_index)
-            try:
-                count_args = len(inspect.signature(self.should_index).parameters)
-            except AttributeError:
-                # noinspection PyDeprecation
-                count_args = len(inspect.getargspec(self.should_index).args)
+            count_args = len(inspect.signature(self.should_index).parameters)
 
-            if is_method or count_args is 1:
+            if is_method or count_args == 1:
                 # bound method, call with instance
                 return self.should_index(instance)
             else:


### PR DESCRIPTION
`get_registered_models` was incorrectly exposed as `get_registered_model` — I've now exposed the correct name, but left the old version there for (temporary) backwards compatibility. 

I've also cleaned up a syntax error reported by @side2k.


